### PR TITLE
Add criticModel option for heterogeneous generator/critic (#6)

### DIFF
--- a/documentation/api.md
+++ b/documentation/api.md
@@ -24,7 +24,8 @@ adhd "..." --json > result.json
 | `--top N` | 3 | how many to deepen / focus |
 | `--concurrency N` | 4 | max parallel LLM calls |
 | `--context PATH` | — | inject a file as context (code, stack, constraints) |
-| `--model NAME` | SDK default | override model |
+| `--model NAME` | SDK default | override model (generator + critic) |
+| `--critic-model NAME` | = `--model` | override model for the critic passes only (score + cluster) — use a different family to decorrelate critic errors |
 | `--no-code-mode` | — | don't bias frames toward engineering |
 | `--json` | — | emit machine-readable `RunResult` |
 | `--quiet` | — | suppress progress events |
@@ -46,7 +47,8 @@ type RunOptions = {
   topK?: number;           // default 3
   concurrency?: number;    // default 4
   codeMode?: boolean;      // default true
-  model?: string;
+  model?: string;          // generator + critic
+  criticModel?: string;    // critic (score + cluster) only; defaults to `model`
   onEvent?: (e: RunEvent) => void;
 };
 ```

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,7 @@ type Flags = {
   json: boolean;
   quiet: boolean;
   model?: string;
+  criticModel?: string;
 };
 
 function parse(argv: string[]): Flags {
@@ -36,6 +37,7 @@ function parse(argv: string[]): Flags {
       case "--concurrency": f.concurrency = Number(argv[++i]); break;
       case "--context": f.context = readFileSync(argv[++i], "utf8"); break;
       case "--model": f.model = argv[++i]; break;
+      case "--critic-model": f.criticModel = argv[++i]; break;
       case "--no-code-mode": f.codeMode = false; break;
       case "--json": f.json = true; break;
       case "--quiet": f.quiet = true; break;
@@ -68,7 +70,9 @@ FLAGS
   --top N           how many to deepen / focus on (default 3)
   --concurrency N   max parallel LLM calls (default 4)
   --context PATH    file to inject as context (code, constraints, stack)
-  --model NAME      override the SDK model
+  --model NAME      override the SDK model (generator + critic)
+  --critic-model N  override the model for the critic passes only
+                    (score + cluster); decorrelates critic errors
   --no-code-mode    don't bias frames toward engineering
   --json            emit RunResult as JSON
   --quiet           suppress progress events
@@ -105,6 +109,7 @@ async function main() {
     concurrency: flags.concurrency,
     codeMode: flags.codeMode,
     model: flags.model,
+    criticModel: flags.criticModel,
     onEvent,
   };
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -238,8 +238,13 @@ export async function run(opts: RunOptions): Promise<RunResult> {
     concurrency = 4,
     codeMode = true,
     model,
+    criticModel,
     onEvent,
   } = opts;
+
+  // The critic (score + cluster) can run on a different model from the
+  // generator to decorrelate errors. Defaults to the generator model.
+  const critic = criticModel ?? model;
 
   const frames = selectFrames(framesPerRun, codeMode);
   const limit = pLimit(concurrency);
@@ -260,8 +265,8 @@ export async function run(opts: RunOptions): Promise<RunResult> {
 
   // PHASE 2 — SCORE + CLUSTER. Critic comes back online.
   const [scoreMap, clusters] = await Promise.all([
-    scoreIdeas(problem, allIdeas, model),
-    clusterIdeas(problem, allIdeas, model),
+    scoreIdeas(problem, allIdeas, critic),
+    clusterIdeas(problem, allIdeas, critic),
   ]);
   for (const i of allIdeas) i.score = scoreMap.get(i.id);
   // Stamp cluster label onto each idea for nicer rendering.

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,7 +53,10 @@ export type RunOptions = {
   topK?: number;                       // how many to deepen, default 3
   concurrency?: number;                // parallel branches, default 4
   codeMode?: boolean;                  // bias frames toward engineering
-  model?: string;                      // override SDK model
+  model?: string;                      // override SDK model (generator + critic)
+  criticModel?: string;                // override model for the critic passes
+                                       // (score + cluster) only; falls back to `model`.
+                                       // Use a different family to decorrelate critic errors.
   onEvent?: (e: RunEvent) => void;     // stream progress to caller/CLI
 };
 


### PR DESCRIPTION
## What

Adds the ability to run the **critic passes (score + cluster) on a different model from the generator**, addressing #6.

- `RunOptions.criticModel` (TypeScript API) — falls back to `model` when unset
- `--critic-model NAME` CLI flag
- Engine routes the score + cluster calls through `criticModel ?? model`; divergence/deepen still use `model`
- Documented in `documentation/api.md` (flag table + `RunOptions`)

## Why

Generator and critic on the same family produce **correlated errors** — the critic misses whatever the generator systematically gets wrong. A cross-family critic (e.g. Claude generator + a different critic) decorrelates those errors, and also directly answers the most-cited eval limitation in the paper (same-model judging).

## Scope / non-goals

Minimal, backward-compatible: default behavior unchanged (critic = generator model). Does not touch the eval harness re-run or skill-side two-agent docs mentioned in the issue — left for follow-ups.

## Testing

`npm run typecheck` passes (both `tsconfig.json` and `tsconfig.bench.json`).

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)