### PR TITLE
Cost accounting: document substrate-multiplied per-run cost (#8)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -277,7 +277,7 @@
 
 <h2 id="impl">Implementation</h2>
 
-<p>We implement ADHD as a Node/TypeScript library on top of the Claude Agent SDK<sup class="cite"><a href="#ref-sdk">[8]</a></sup>. The package ships a CLI (<code>adhd "&lt;problem&gt;"</code>), a programmatic API (<code>run(opts) → RunResult</code>), and a frame library that is extensible in five lines per frame. A default run uses <em>N</em> = 5 frames, <em>k</em> = 6 ideas per frame, <em>K</em> = 3 deepened survivors, concurrency 4. Total LLM calls per run: <em>N</em> divergences + 1 score + 1 cluster + <em>K</em> deepens ≈ 10.</p>
+<p>We implement ADHD as a Node/TypeScript library on top of the Claude Agent SDK<sup class="cite"><a href="#ref-sdk">[8]</a></sup>. The package ships a CLI (<code>adhd "&lt;problem&gt;"</code>), a programmatic API (<code>run(opts) → RunResult</code>), and a frame library that is extensible in five lines per frame. A default run uses <em>N</em> = 5 frames, <em>k</em> = 6 ideas per frame, <em>K</em> = 3 deepened survivors, concurrency 4. Total LLM calls per run: <em>N</em> divergences + 1 score + 1 cluster + <em>K</em> deepens ≈ 10. Call count is a poor proxy for cost, however; see <a href="#cost">Cost</a> for the substrate-multiplied token accounting.</p>
 
 <p>Each phase uses a system prompt tuned for its posture. Divergence prompts begin with <em>"You are in DIVERGENT mode. You are a generator, not a critic"</em> and enumerate constraints (JSON only, no prose, no ranking, the first three obvious answers are banned, push past them). The scoring prompt begins with <em>"You are in CONVERGENT mode. You are now the critic"</em> and supplies the rubric. The deepen prompt begins with <em>"You are in FOCUS mode"</em>. These prompts are designed to be self-evidently incompatible, so the model cannot drift between them within a single call.</p>
 
@@ -341,8 +341,10 @@
 
 <p>This matches the failure mode we expect. When the problem is <em>well-understood with a known good answer</em>, a single polished answer beats a wide set with the same answer buried in it. ADHD pays its cost in presentation overhead; that cost is worth it precisely when the wide set <em>contains</em> ideas the polished answer missed. On <em>llm-hang-cli</em> the baseline already knew the right answer; on the other five problems it did not.</p>
 
-<h3>Cost</h3>
-<p>A default ADHD run uses ≈10 LLM calls (5 divergence + 1 score + 1 cluster + 3 deepen) versus 1 for the baseline. Wall-clock latency at concurrency 4 is typically 30–90 s. We frame this honestly: ADHD is for decision points, not inner loops. The right mental model is <em>spend US$0.30 to widen a US$50k architecture decision</em>.</p>
+<h3 id="cost">Cost</h3>
+<p>A default ADHD run uses ≈10 LLM calls (5 divergence + 1 score + 1 cluster + 3 deepen) versus 1 for the baseline. Wall-clock latency at concurrency 4 is typically 30–90 s. <em>Call count, however, understates token cost.</em> Because each divergence branch is an isolated context, the base substrate that prefixes every call (system prompt, and — when ADHD runs as a skill inside an agent session — the host's context and tool definitions) is paid once <em>per branch</em>, before any divergence token is generated. The honest cost is therefore</p>
+<p style="text-align:center"><em>cost ≈ N × (base_context + branch_output) + critic_context + K × deepen_context</em>,</p>
+<p>where the <em>N ×</em> multiplier on <em>base_context</em> dominates whenever the substrate is large. Two regimes follow: the <strong>standalone library</strong> carries a minimal substrate (problem + frame only), so its premium is close to the naive 5–10× call ratio; the <strong>skill-inside-an-agent</strong> regime re-loads the host substrate on every branch, so its premium is higher and grows with <em>N</em>. We frame this honestly: ADHD is for decision points, not inner loops. The right mental model is <em>spend a small, computable token premium to widen a high-stakes decision</em> — the dollar figure depends on <em>N</em>, the base substrate, and current per-token pricing, and should be computed per deployment rather than quoted as a single headline number.</p>
 
 <h2 id="discussion">Discussion and limitations</h2>
 

--- a/documentation/when-to-use.md
+++ b/documentation/when-to-use.md
@@ -43,8 +43,25 @@ Honest numbers. A default run is roughly:
 - 1 clustering call
 - K deepen calls (default 3)
 
-≈ **10 LLM calls per run**, 5–10× a single-shot baseline. Latency depends on concurrency; 30–90s wall clock is typical.
+That is ≈ **N + K + 2 calls** (≈10 at defaults). But **call count is the wrong unit** — token cost is what you pay, and it is dominated by *context that gets re-loaded on every branch*, not by the novel output.
 
-Frame it as: **$0.30 to widen a $50k architecture decision.** Don't run it on every keystroke. Run it at decision points.
+### The honest cost formula
 
-> Note: the per-run cost depends on your base context. Inside a Claude Code session with a large `CLAUDE.md` + tool context, each of the N branches re-loads that base substrate, so real token cost is closer to `N × (base + branch)`. See [issue #8](https://github.com/UditAkhourii/adhd/issues/8).
+Each divergence branch is a fresh, isolated context (that isolation is the whole point — see [how it works](./how-it-works.md)). So the base substrate that prefixes every call — your `CLAUDE.md`, state files, and tool context inside a Claude Code session — is paid **once per branch**, before a single novel idea token is generated:
+
+```
+cost ≈ N × (base_context + branch_output)   ← divergence
+     + critic_context                        ← score + cluster see all N×k ideas
+     + K × deepen_context                    ← focus passes
+```
+
+The `N ×` multiplier on `base_context` is the part the simple "10 calls" framing hides. If the base substrate is ~26K tokens, five branches re-load ~130K tokens of substrate **before** any divergence — that is the real floor, and it scales with `N`, not with how much the model actually says.
+
+### Substrate matters more than call count
+
+- **Standalone library** (`adhd "..."`): minimal substrate. Each branch carries only the problem + frame prompt, so `base_context` is small and the premium is modest — close to the naive 5–10× figure.
+- **Skill inside a Claude Code session**: large substrate. Every branch re-loads `CLAUDE.md` + tool context, so the premium is **meaningfully higher** than the library and grows with your session's base context. Budget for `N × base`, not `1 × base`.
+
+### Rule of thumb
+
+Frame it as: **a few cents to a few dollars to widen a high-stakes decision** — the exact figure depends on `N`, your base substrate, and current API pricing, so compute it for your own setup rather than trusting a single headline number. The mental model holds regardless: cheap relative to shipping the wrong obvious answer. Don't run it on every keystroke. Run it at decision points.


### PR DESCRIPTION
## What

Replaces the "≈10 LLM calls, 5–10× a single answer" framing with honest, substrate-multiplied token accounting, per #8.

- **`documentation/when-to-use.md`** — Cost & speed section: adds the real formula and the library-vs-skill distinction.
- **`docs/index.html`** (paper) — §Cost (Analysis) carries the same accounting; §Implementation links to it; the hardcoded "$0.30 / $50k" headline is replaced with a per-deployment computation.

## The core correction

```
cost ≈ N × (base_context + branch_output) + critic_context + K × deepen_context
```

Call count understates cost because each divergence branch is an **isolated context**, so the base substrate (`CLAUDE.md` + tool context in a Claude Code session) is paid **once per branch** — the `N ×` multiplier the "10 calls" line hides. Consequence documented: the premium is modest for the standalone library (small substrate) but meaningfully higher for the skill-inside-an-agent regime (large substrate, re-loaded N times).

The single "$0.30 to widen a $50k decision" figure is dropped in favor of "compute it for your N + substrate + current pricing," since a fixed number can't survive those variables.

## Scope

Docs/paper only — no code change. The "re-validate against current API pricing" sub-task in the issue is left to a numbers pass; this PR fixes the *model* of cost so any future figure is computed correctly.

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)