### PR TITLE
fix: disable tools for generation-only queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   ],
   "scripts": {
     "build": "tsc",
+    "test": "node --import tsx --test tests/*.test.ts",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.bench.json",
     "prepublishOnly": "npm run build",
     "dev": "tsx src/cli.ts",

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -14,18 +14,25 @@ export type LLMOptions = {
   userPrompt: string;
 };
 
+export function buildQueryOptions(opts: LLMOptions) {
+  return {
+    model: opts.model,
+    systemPrompt: {
+      type: "preset" as const,
+      preset: "claude_code" as const,
+      append: opts.systemPrompt,
+    },
+    // No tools — divergence is pure generation. Tools = convergence pressure.
+    tools: [] as string[],
+  };
+}
+
 export async function callLLM(opts: LLMOptions): Promise<string> {
   const chunks: string[] = [];
 
   const iter = query({
     prompt: opts.userPrompt,
-    options: {
-      model: opts.model,
-      systemPrompt: { type: "preset", preset: "claude_code", append: opts.systemPrompt },
-      // No tools — divergence is pure generation. Tools = convergence pressure.
-      allowedTools: [],
-      permissionMode: "bypassPermissions",
-    },
+    options: buildQueryOptions(opts),
   });
 
   for await (const message of iter) {

--- a/tests/llm.test.ts
+++ b/tests/llm.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildQueryOptions } from "../src/llm.ts";
+
+test("generation-only queries disable all built-in tools", () => {
+  const options = buildQueryOptions({
+    model: "claude-sonnet-4-5",
+    systemPrompt: "Think divergently.",
+    userPrompt: "Generate ideas.",
+  });
+
+  assert.deepEqual(options.tools, []);
+  assert.equal("allowedTools" in options, false);
+  assert.equal("permissionMode" in options, false);
+});


### PR DESCRIPTION
## Summary

- configure divergence queries with `tools: []` so built-in Claude Code tools are unavailable
- remove `permissionMode: "bypassPermissions"` from generation-only sessions
- add a regression test covering the intended no-tools configuration

## Rationale

The wrapper describes divergence as pure generation with no tools. In the Claude Agent SDK, `allowedTools` controls which available tools are automatically approved; an empty array does not restrict tool availability. The `tools` option defines the available built-in tool set, and `tools: []` disables it.

This change makes the runtime configuration match the existing generation-only design.

## Verification

- [x] `npm test`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm pack --dry-run`
