### PR TITLE
docs: surface community note at top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 [![Paper](https://img.shields.io/badge/paper-preprint-blueviolet)](https://adhdstack.github.io/)
 [![Featured: The New Stack](https://img.shields.io/badge/featured-The%20New%20Stack-ff5500)](https://thenewstack.io/claude-code-adhd/)
 
+> 👉 [**Join the ADHD community →**](https://tally.so/r/WO1Nzj) as a contributor, maintainer, early adopter, or just a member. One short form. We coordinate frame contributions, eval problems, integrations, and adopter onboarding there.
+
 > **An architectural fix for premature convergence in autoregressive reasoning.**
 
 Linear Chain-of-Thought anchors on whatever it says first. Tree-of-Thought widens the search but still walks a single shared context, so the anchoring persists across branches. **ADHD treats this as an architectural problem, not a prompting one** — it spawns N isolated reasoning processes under deliberately distorted cognitive frames, with zero shared context during divergence, then runs a separate critic pass to score, cluster, prune traps, and deepen the survivors.


### PR DESCRIPTION
## Summary

- Add the "Join the ADHD community" note right after the badges at the top of the README, above the hero blockquote
- Reuses the exact wording and link (tally.so/r/WO1Nzj) already present in the `## Community` section further down — no new content, just earlier visibility

## Why

Readers currently have to scroll past the hero section, the side-by-side eval example, and the Featured section before hitting the community CTA. Surfacing it right under the badges gives it visibility at the very top of the page.

## Test plan

- [x] Rendered the README locally to confirm the note displays correctly as a blockquote note right after the badges
- [x] Confirmed the link matches the existing Community section (no drift between the two mentions)