### PR TITLE
feat: add symmetric strength signal to the critic pass

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -37,6 +37,7 @@ const ScoreRowSchema = z.array(
     viability: z.number().min(0).max(10),
     fit: z.number().min(0).max(10),
     trap: z.string().optional(),
+    strength: z.string().optional(),
   }),
 );
 
@@ -66,9 +67,19 @@ Score each idea on three axes 0-10:
 - novelty: distance from the obvious default solution
 - viability: could this actually ship / work in practice
 - fit: how directly it addresses the stated problem
-If the idea looks attractive but is a TRAP (hidden cost, false economy,
-will-not-scale, premature abstraction), set "trap" to a one-line reason.
-Otherwise omit "trap".
+
+Tell the truth about weaknesses — don't soften the substance. But the
+critic's job is to produce two symmetric signals, not just one:
+
+- "strength": required for every idea, even weak ones. The single most
+  concrete thing this idea gets right that a competing idea doesn't.
+- "trap" (optional): if the idea looks attractive but has a hidden cost
+  (false economy, won't scale, premature abstraction), name it as a
+  specific, actionable heads-up — e.g. "solid for a prototype, breaks
+  past 10k concurrent users" — not a dismissal like "bad idea." The
+  fact stays the fact; only the framing changes: information you can
+  act on, not a verdict on the idea's worth.
+
 Output JSON only.`;
 
 const CLUSTER_SYSTEM = `You group ideas into 3-6 clusters by their UNDERLYING ANGLE
@@ -139,7 +150,7 @@ IDEAS (id → text):
 ${ideas.map((i) => `${i.id} :: ${i.text}`).join("\n")}
 
 Score each. Output JSON array:
-[{"id":"...","novelty":0-10,"viability":0-10,"fit":0-10,"trap":"... or omit"}]`;
+[{"id":"...","novelty":0-10,"viability":0-10,"fit":0-10,"strength":"...","trap":"... or omit"}]`;
 
   const raw = await callLLM({
     model,
@@ -165,6 +176,7 @@ Score each. Output JSON array:
       fit: r.fit,
       total,
       trap: r.trap,
+      strength: r.strength,
     });
   }
   return out;

--- a/src/render.ts
+++ b/src/render.ts
@@ -50,14 +50,16 @@ export function renderText(r: RunResult): string {
     const mark = r.nonObviousPick?.id === i.id ? green("★ non-obvious pick → ") : "  ";
     out.push(`  ${mark}${i.text} ${chip(i)}`);
     if (i.rationale) out.push(`    ${dim(i.rationale)}`);
+    if (i.score?.strength) out.push(`    ${green("+")} ${dim(i.score.strength)}`);
   }
   out.push("");
 
   if (r.traps.length > 0) {
-    out.push(bold("Traps (look good, aren't)"));
+    out.push(bold("Traps (watch-outs, not verdicts)"));
     for (const t of r.traps) {
       out.push(`  ${red("⚠")} ${t.text}`);
       out.push(`    ${dim(t.score?.trap ?? "")}`);
+      if (t.score?.strength) out.push(`    ${green("+")} ${dim(t.score.strength)}`);
     }
     out.push("");
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ export type Score = {
   fit: number;         // 0-10, addresses the stated problem
   total: number;       // weighted
   trap?: string;       // if it looks good but is a trap, why
+  strength?: string;   // the one concrete thing this idea gets right
 };
 
 export type Branch = {


### PR DESCRIPTION
## Add a symmetric "strength" signal to the critic pass

**What this changes:** the critic (`SCORE_SYSTEM` in `src/engine.ts`) currently only has one qualitative signal it can hand back — `trap`, which names what's *wrong* with an idea. This PR adds an equally-required `strength` field that names the one concrete thing an idea gets *right*, even when the idea scores low or gets flagged as a trap.

**Why:** the scoring axes (novelty/viability/fit) and the trap-detection stay exactly as strict as before — nothing about *what* gets measured changes. But right now the only prose feedback a user gets is about weaknesses. Adding a required strength line makes the critic's feedback symmetric: every idea gets told what's useful about it, not just what's wrong with it. This is a small UX/tone change in the same spirit as issue #11 (brain-model series) — useful for anyone, but especially for users who default to over-weighting critique.

**What this does NOT change:**
- No change to the diverge/critic separation, score-before-deepen ordering, or cluster-by-angle logic — all load-bearing invariants from CONTRIBUTING.md are untouched.
- `trap` is still exactly as blunt about real weaknesses as before.
- `strength` is optional in the type/schema, preserving backward compatibility.

**Files touched:**
- `src/types.ts` — add optional `strength?: string` to `Score`
- `src/engine.ts` — add `strength` to the zod schema, update `SCORE_SYSTEM` prompt, carry `strength` into returned `Score`
- `src/render.ts` — display `strength` next to shortlist items and traps