### PR TITLE
Add cluster-level narrowing as alternative to idea-level deepening

### DIFF
--- a/documentation/api.md
+++ b/documentation/api.md
@@ -27,6 +27,7 @@ adhd "..." --json > result.json
 | `--model NAME` | SDK default | override model (generator + critic) |
 | `--critic-model NAME` | = `--model` | override model for the critic passes only (score + cluster) — use a different family to decorrelate critic errors |
 | `--no-code-mode` | — | don't bias frames toward engineering |
+| `--deepen-mode M` | `idea` | `idea` deepens the top-K ranked ideas; `cluster` ranks clusters instead and re-diverges inside the top-K clusters for implementation variants |
 | `--json` | — | emit machine-readable `RunResult` |
 | `--quiet` | — | suppress progress events |
 
@@ -47,6 +48,7 @@ type RunOptions = {
   topK?: number;           // default 3
   concurrency?: number;    // default 4
   codeMode?: boolean;      // default true
+  deepenMode?: "idea" | "cluster"; // default "idea"
   model?: string;          // generator + critic
   criticModel?: string;    // critic (score + cluster) only; defaults to `model`
   onEvent?: (e: RunEvent) => void;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,7 @@ type Flags = {
   top?: number;
   concurrency?: number;
   codeMode: boolean;
+  deepenMode: "idea" | "cluster";
   json: boolean;
   quiet: boolean;
   model?: string;
@@ -41,7 +42,7 @@ function positiveInt(raw: string, flag: string, max: number): number {
 const MAX_CONTEXT_BYTES = 10 * 1024 * 1024; // 10 MB
 
 function parse(argv: string[]): Flags {
-  const f: Flags = { problem: "", codeMode: true, json: false, quiet: false };
+  const f: Flags = { problem: "", codeMode: true, deepenMode: "idea", json: false, quiet: false };
   const rest: string[] = [];
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
@@ -63,6 +64,15 @@ function parse(argv: string[]): Flags {
       case "--model": f.model = argv[++i]; break;
       case "--critic-model": f.criticModel = argv[++i]; break;
       case "--no-code-mode": f.codeMode = false; break;
+      case "--deepen-mode": {
+        const v = argv[++i];
+        if (v !== "idea" && v !== "cluster") {
+          console.error(`Error: --deepen-mode must be "idea" or "cluster", got "${v}"`);
+          process.exit(1);
+        }
+        f.deepenMode = v;
+        break;
+      }
       case "--json": f.json = true; break;
       case "--quiet": f.quiet = true; break;
       case "-h":
@@ -98,6 +108,9 @@ FLAGS
   --critic-model N  override the model for the critic passes only
                     (score + cluster); decorrelates critic errors
   --no-code-mode    don't bias frames toward engineering
+  --deepen-mode M   "idea" (default) deepens the top-K ranked ideas;
+                    "cluster" ranks clusters instead and re-diverges inside
+                    the top-K clusters for implementation variants
   --json            emit RunResult as JSON
   --quiet           suppress progress events
   -h, --help
@@ -132,6 +145,7 @@ async function main() {
     topK: flags.top,
     concurrency: flags.concurrency,
     codeMode: flags.codeMode,
+    deepenMode: flags.deepenMode,
     model: flags.model,
     criticModel: flags.criticModel,
     onEvent,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -84,6 +84,16 @@ const DEEPEN_SYSTEM = `You are in FOCUS mode. Take one promising idea and connec
   combinations with other domains, things this unlocks).
 Output JSON only.`;
 
+const DEEPEN_CLUSTER_SYSTEM = `You are in FOCUS mode, working at the CLUSTER level, not a single idea.
+You are given a whole cluster of ideas that share an underlying angle.
+- Sketch how the ANGLE would actually work as a real approach (4-8
+  sentences), synthesizing across the cluster rather than picking one member.
+- Name the load-bearing risk of committing to this angle.
+- Name the first concrete step a coder would take.
+- Then generate 3-5 IMPLEMENTATION VARIANTS of this angle — different ways
+  to execute the same underlying idea, not just recombinations of one leaf.
+Output JSON only.`;
+
 async function divergeBranch(
   problem: string,
   context: string | undefined,
@@ -251,6 +261,74 @@ Output JSON:
   return { ideaId: idea.id, sketch: parsed.sketch, childIdeas };
 }
 
+async function deepenCluster(
+  problem: string,
+  cluster: Cluster,
+  members: Idea[],
+  model: string | undefined,
+): Promise<DeepenedIdea> {
+  // Anchor the DeepenedIdea to the cluster's top-scoring member so existing
+  // consumers (render.ts) can still resolve a parent idea to show alongside
+  // the cluster-level sketch.
+  const anchor = [...members].sort(
+    (a, b) => (b.score?.total ?? 0) - (a.score?.total ?? 0),
+  )[0];
+
+  const userPrompt = `PROBLEM:
+${problem}
+
+CLUSTER — ${cluster.label}:
+${members.map((m) => `- ${m.text}`).join("\n")}
+
+Output JSON:
+{
+  "sketch": "4-8 sentences. How the angle works. Load-bearing risk. First concrete step.",
+  "childIdeas": [
+    {"text": "...", "rationale": "implementation variant of this angle"}
+  ]
+}`;
+
+  const raw = await callLLM({
+    model,
+    systemPrompt: DEEPEN_CLUSTER_SYSTEM,
+    userPrompt,
+  });
+
+  let parsed: z.infer<typeof DeepenSchema>;
+  try {
+    parsed = parseJSON(raw, DeepenSchema);
+  } catch {
+    return { ideaId: anchor.id, sketch: "(deepen pass failed to parse)", childIdeas: [] };
+  }
+
+  const childIdeas: Idea[] = parsed.childIdeas.map((c) => ({
+    id: randomUUID(),
+    frameId: anchor.frameId,
+    cluster: cluster.label,
+    text: c.text,
+    rationale: c.rationale,
+    depth: anchor.depth + 1,
+    parentId: anchor.id,
+  }));
+
+  return { ideaId: anchor.id, sketch: parsed.sketch, childIdeas };
+}
+
+// Rank clusters by mean score of their non-trap members. Traps are excluded
+// so one attractive-looking-but-flawed idea doesn't inflate a weak cluster.
+// Exported (pure, no I/O) so it's unit-testable without an LLM call.
+export function rankClusters(clusters: Cluster[], allIdeas: Idea[]): Cluster[] {
+  const byId = new Map(allIdeas.map((i) => [i.id, i]));
+  const score = (c: Cluster): number => {
+    const viable = c.ideaIds
+      .map((id) => byId.get(id))
+      .filter((i): i is Idea => Boolean(i?.score && !i.score.trap));
+    if (viable.length === 0) return -Infinity;
+    return viable.reduce((sum, i) => sum + i.score!.total, 0) / viable.length;
+  };
+  return [...clusters].sort((a, b) => score(b) - score(a));
+}
+
 export async function run(opts: RunOptions): Promise<RunResult> {
   const {
     problem,
@@ -260,6 +338,7 @@ export async function run(opts: RunOptions): Promise<RunResult> {
     topK = 3,
     concurrency = 4,
     codeMode = true,
+    deepenMode = "idea",
     model,
     criticModel,
     onEvent,
@@ -318,17 +397,38 @@ export async function run(opts: RunOptions): Promise<RunResult> {
         )[0];
 
   // PHASE 3 — FOCUS / DEEPEN top-K. This is the "connecting the dots" pass.
-  const toDeepen = ranked.slice(0, topK);
-  const deepened = await Promise.all(
-    toDeepen.map((idea) =>
-      limit(async () => {
-        onEvent?.({ kind: "deepen:start", ideaId: idea.id, text: idea.text });
-        const d = await deepenIdea(problem, idea, allIdeas, model);
-        onEvent?.({ kind: "deepen:done", ideaId: idea.id });
-        return d;
-      }),
-    ),
-  );
+  // "idea" mode (default) goes deep on specific ideas — may miss adjacent
+  // implementation variants that live in the same cluster.
+  // "cluster" mode goes broad-then-deep within the winning angles instead —
+  // ranks clusters, re-diverges inside the top-K to surface variants of the
+  // angle rather than variations of a single leaf.
+  const deepened =
+    deepenMode === "cluster"
+      ? await Promise.all(
+          rankClusters(clusters, allIdeas)
+            .slice(0, topK)
+            .map((c) =>
+              limit(async () => {
+                const members = c.ideaIds
+                  .map((id) => allIdeas.find((i) => i.id === id))
+                  .filter((i): i is Idea => Boolean(i));
+                onEvent?.({ kind: "deepen:start", ideaId: c.label, text: c.label });
+                const d = await deepenCluster(problem, c, members, model);
+                onEvent?.({ kind: "deepen:done", ideaId: c.label });
+                return d;
+              }),
+            ),
+        )
+      : await Promise.all(
+          ranked.slice(0, topK).map((idea) =>
+            limit(async () => {
+              onEvent?.({ kind: "deepen:start", ideaId: idea.id, text: idea.text });
+              const d = await deepenIdea(problem, idea, allIdeas, model);
+              onEvent?.({ kind: "deepen:done", ideaId: idea.id });
+              return d;
+            }),
+          ),
+        );
 
   // One provocation = a wild-tagged frame's lowest-scoring-but-highest-novelty leaf,
   // reframed as a question. Cheap, doesn't need another LLM call.

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,10 @@ export type RunOptions = {
   topK?: number;                       // how many to deepen, default 3
   concurrency?: number;                // parallel branches, default 4
   codeMode?: boolean;                  // bias frames toward engineering
+  deepenMode?: "idea" | "cluster";     // "idea" (default) deepens the top-K
+                                       // ranked ideas; "cluster" ranks clusters
+                                       // instead and re-diverges inside the
+                                       // top-K clusters for implementation variants
   model?: string;                      // override SDK model (generator + critic)
   criticModel?: string;                // override model for the critic passes
                                        // (score + cluster) only; falls back to `model`.

--- a/tests/engine.test.ts
+++ b/tests/engine.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { rankClusters } from "../src/engine.ts";
+import type { Cluster, Idea } from "../src/types.ts";
+
+function idea(id: string, total: number, trap?: string): Idea {
+  return {
+    id,
+    frameId: "f",
+    text: id,
+    depth: 0,
+    score: { novelty: total, viability: total, fit: total, total, trap },
+  };
+}
+
+test("rankClusters orders by mean score of non-trap members", () => {
+  const strong = idea("a", 9);
+  const weak = idea("b", 2);
+  const clusters: Cluster[] = [
+    { label: "weak-angle", ideaIds: ["b"] },
+    { label: "strong-angle", ideaIds: ["a"] },
+  ];
+
+  const ranked = rankClusters(clusters, [strong, weak]);
+
+  assert.deepEqual(ranked.map((c) => c.label), ["strong-angle", "weak-angle"]);
+});
+
+test("rankClusters excludes trapped ideas from a cluster's score", () => {
+  const trap = idea("a", 9, "looks good, isn't");
+  const viable = idea("b", 5);
+  const clusters: Cluster[] = [
+    { label: "trap-only", ideaIds: ["a"] },
+    { label: "mixed", ideaIds: ["a", "b"] },
+  ];
+
+  const ranked = rankClusters(clusters, [trap, viable]);
+
+  // "trap-only" has no viable members, so it sorts last.
+  assert.deepEqual(ranked.map((c) => c.label), ["mixed", "trap-only"]);
+});
+
+test("rankClusters handles clusters referencing unknown idea ids", () => {
+  const clusters: Cluster[] = [{ label: "orphan", ideaIds: ["missing"] }];
+  const ranked = rankClusters(clusters, []);
+  assert.equal(ranked.length, 1);
+  assert.equal(ranked[0].label, "orphan");
+});


### PR DESCRIPTION
## Summary
- Adds `deepenMode: "idea" | "cluster"` (default `"idea"`, unchanged behavior) to `RunOptions`, and `--deepen-mode idea|cluster` to the CLI.
- `"cluster"` mode ranks clusters by the mean score of their non-trap members (`rankClusters()`, exported as a pure function) and re-diverges inside the top-K clusters, producing implementation variants of the winning *angle* instead of variations of a single leaf idea.
- The resulting `DeepenedIdea` stays anchored to the cluster's top-scoring member's id, so `render.ts`'s existing parent-idea lookup works unmodified for both modes.

Closes #15.

## Why
As raised in #15: idea-level deepening (current default) can miss adjacent implementation variants that live in the same winning cluster. Cluster-level narrowing goes broad-then-deep within the winning angles instead. Per the issue, each mode likely wins on different problem categories — that's a question for the eval harness (#14 / #18), not something to hardcode a winner for here.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test` — added `tests/engine.test.ts` covering `rankClusters()`: ranks by mean score, excludes trapped members, handles clusters referencing unknown idea ids
- [ ] End-to-end run with `--deepen-mode cluster` against a live problem (needs API access; not run in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)