### PR TITLE
feat: add plugin manifest so the repo installs as a Claude Code plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,29 @@
+{
+  "name": "adhd",
+  "owner": {
+    "name": "ADHD contributors",
+    "url": "https://github.com/UditAkhourii/adhd"
+  },
+  "plugins": [
+    {
+      "name": "adhd",
+      "source": "./",
+      "description": "Parallel divergent ideation for coding agents: fans out isolated branches under different cognitive frames, scores, clusters, prunes traps, and deepens the survivors.",
+      "version": "0.1.4",
+      "author": {
+        "name": "ADHD contributors"
+      },
+      "homepage": "https://github.com/UditAkhourii/adhd#readme",
+      "repository": "https://github.com/UditAkhourii/adhd",
+      "license": "MIT",
+      "category": "productivity",
+      "keywords": [
+        "ideation",
+        "brainstorm",
+        "divergent-thinking",
+        "tree-of-thought",
+        "architecture"
+      ]
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "adhd",
+  "version": "0.1.4",
+  "description": "Parallel divergent ideation for coding agents: fans out isolated branches under different cognitive frames, scores, clusters, prunes traps, and deepens the survivors.",
+  "author": {
+    "name": "ADHD contributors"
+  },
+  "homepage": "https://github.com/UditAkhourii/adhd#readme",
+  "repository": "https://github.com/UditAkhourii/adhd",
+  "license": "MIT",
+  "keywords": [
+    "ideation",
+    "brainstorm",
+    "divergent-thinking",
+    "tree-of-thought",
+    "architecture"
+  ]
+}


### PR DESCRIPTION
## What

Adds a plugin manifest so the repository can be installed as a Claude Code plugin:

- `.claude-plugin/plugin.json` — plugin manifest
- `.claude-plugin/marketplace.json` — single-plugin marketplace entry with `source: "./"`, so the repo doubles as its own marketplace

## Why

Alongside the existing npm distribution, users could then install with:

```
/plugin marketplace add UditAkhourii/adhd
/plugin install adhd@adhd
```

`skills/adhd/SKILL.md` is picked up by the standard skill loader, so no skill or source files change and nothing about the npm package is affected. Version and metadata mirror `package.json` (0.1.4, MIT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
